### PR TITLE
feat: Use URL to append path safely to baseURL

### DIFF
--- a/src/Structures/REST.ts
+++ b/src/Structures/REST.ts
@@ -87,7 +87,7 @@ export class REST {
 	public async get<T>(route: string, init?: RequestInit | undefined): Promise<T> {
 		await this.queue.wait();
 		try {
-			return fetch(`${this.url}${route}`, { headers: this.headers, ...init }, FetchResultTypes.JSON);
+			return fetch(new URL(route, this.url), { headers: this.headers, ...init }, FetchResultTypes.JSON);
 		} finally {
 			this.queue.shift();
 		}
@@ -96,7 +96,7 @@ export class REST {
 	public async post<T>(route: string, init?: RequestInit | undefined): Promise<T> {
 		await this.queue.wait();
 		try {
-			return fetch(`${this.url}${route}`, { headers: this.headers, method: 'POST', ...init }, FetchResultTypes.JSON);
+			return fetch(new URL(route, this.url), { headers: this.headers, method: 'POST', ...init }, FetchResultTypes.JSON);
 		} finally {
 			this.queue.shift();
 		}


### PR DESCRIPTION
This will safely append path to baseURL and will not cause something like this:

```js
const baseURL = "http://localhost:2333/";
const route = "/loadTracks";

const finalURLBad = `${baseURL}${loadTracks}`; // becomes http://localhost:2333//loadTracks (will 404)

const finalURL = new URL(route, baseURL); // becomes http://localhost:2333/loadTracks.
```